### PR TITLE
Prevent fatal error when using Chrome extensions for graphql querying

### DIFF
--- a/Test/Unit/Validator/CorsValidatorTest.php
+++ b/Test/Unit/Validator/CorsValidatorTest.php
@@ -52,6 +52,15 @@ class CorsValidatorTest extends \PHPUnit\Framework\TestCase
         return $this->assertEquals($expected, $this->validator->originIsValid());
     }
 
+    public function testInvalidOriginScheme()
+    {
+        $this->configurationMock->method('getAllowedOrigins')->willReturn(['*']);
+        $this->requestMock->method('getHeader')->willThrowException(
+            new \Zend\Uri\Exception\InvalidArgumentException
+        );
+        return $this->assertEquals(false, $this->validator->originIsValid());
+    }
+
     public function originIsValidDataProvider()
     {
         return [

--- a/Validator/CorsValidator.php
+++ b/Validator/CorsValidator.php
@@ -62,21 +62,29 @@ class CorsValidator implements CorsValidatorInterface
      */
     public function originIsValid(): bool
     {
-        $isValid = false;
         if ($this->request instanceof HttpRequest) {
             //Validate that we're working with something that cares about CORS
-            try {
-                if (!$this->request->getHeader('Origin')) {
-                    $isValid = false;
-                }
-
-                $isValid = $this->configurationIsWildcard() || $this->requestOriginExistsInConfiguration();
-            } catch (\Zend\Uri\Exception\InvalidArgumentException $exception) {
-                // Ignore the case of non-standard URI schemes (e.g. chrome-extension://)
-                $isValid = false;
+            if (!$this->originHeaderExists()) {
+                return false;
             }
+
+            return $this->configurationIsWildcard() || $this->requestOriginExistsInConfiguration();
         }
 
-        return $isValid;
+        return false;
+    }
+
+    /**
+     * Determines whether an origin header exists with a valid scheme.
+     * @return bool
+     */
+    private function originHeaderExists(): bool
+    {
+        try {
+            return $this->request->getHeader('Origin') ? true : false;
+        } catch (\Zend\Uri\Exception\InvalidArgumentException $exception) {
+            // In the event of an invalid URI scheme, e.g. chrome-extension://
+            return false;
+        }
     }
 }

--- a/Validator/CorsValidator.php
+++ b/Validator/CorsValidator.php
@@ -62,14 +62,21 @@ class CorsValidator implements CorsValidatorInterface
      */
     public function originIsValid(): bool
     {
+        $isValid = false;
         if ($this->request instanceof HttpRequest) {
             //Validate that we're working with something that cares about CORS
-            if (!$this->request->getHeader('Origin')) {
-                return false;
-            }
+            try {
+                if (!$this->request->getHeader('Origin')) {
+                    $isValid = false;
+                }
 
-            return $this->configurationIsWildcard() || $this->requestOriginExistsInConfiguration();
+                $isValid = $this->configurationIsWildcard() || $this->requestOriginExistsInConfiguration();
+            } catch (\Zend\Uri\Exception\InvalidArgumentException $exception) {
+                // Ignore the case of non-standard URI schemes (e.g. chrome-extension://)
+                $isValid = false;
+            }
         }
-        return false;
+
+        return $isValid;
     }
 }


### PR DESCRIPTION
Hey team; thanks for providing this - it's going to be a big help for our Headless efforts.

One problem I have though is that I use a GraphQL Chrome extension (Altair) for my testing, which sends an Origin Request header with a chrome-extension:// scheme. The Zend framework fails to validate that as part of the getHeader() call, and throws an error.

I've proposed that we catch this specific exception and treat it the same way as a request without an Origin header.

Shout out if you have any thoughts or concerns.