### PR TITLE
Add header provider for Access-Control-Allow-Credentials

### DIFF
--- a/Configuration/CorsConfigurationInterface.php
+++ b/Configuration/CorsConfigurationInterface.php
@@ -35,4 +35,9 @@ interface CorsConfigurationInterface
      * @return string;
      */
     public function getMaxAge(): ?string;
+
+    /**
+     * @return bool
+     */
+    public function getAllowCredentials(): bool;
 }

--- a/Configuration/GraphQl/CorsConfiguration.php
+++ b/Configuration/GraphQl/CorsConfiguration.php
@@ -27,6 +27,8 @@ class CorsConfiguration implements CorsConfigurationInterface
 
     const XML_PATH_GRAPHQL_CORS_MAX_AGE = 'web/graphql/cors_max_age';
 
+    const XML_PATH_GRAPHQL_CORS_CREDENTIALS = 'web/graphql/cors_allow_credentials';
+
     /** @var ScopeConfigInterface */
     private $scopeConfig;
 
@@ -83,5 +85,13 @@ class CorsConfiguration implements CorsConfigurationInterface
     public function getMaxAge(): string
     {
         return $this->scopeConfig->getValue(self::XML_PATH_GRAPHQL_CORS_MAX_AGE);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowCredentials(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_GRAPHQL_CORS_CREDENTIALS);
     }
 }

--- a/Configuration/Rest/CorsConfiguration.php
+++ b/Configuration/Rest/CorsConfiguration.php
@@ -27,6 +27,8 @@ class CorsConfiguration implements CorsConfigurationInterface
 
     const XML_PATH_WEBAPI_REST_CORS_MAX_AGE = 'web/api_rest/cors_max_age';
 
+    const XML_PATH_REST_CORS_CREDENTIALS = 'web/api_rest/cors_allow_credentials';
+
     /** @var ConfigurationCleaner */
     private $cleaner;
 
@@ -83,5 +85,13 @@ class CorsConfiguration implements CorsConfigurationInterface
     public function getMaxAge(): string
     {
         return $this->scopeConfig->getValue(self::XML_PATH_WEBAPI_REST_CORS_MAX_AGE);
+    }
+
+    /**
+     * @return bool
+     */
+    public function getAllowCredentials(): bool
+    {
+        return $this->scopeConfig->isSetFlag(self::XML_PATH_REST_CORS_CREDENTIALS);
     }
 }

--- a/README.md
+++ b/README.md
@@ -39,6 +39,8 @@ composer require graycore/magento2-cors
     * `Access-Control-Allow-Methods`
     * `Access-Control-Allow-Headers`
     * `Access-Control-Max-Age`
+    * `Access-Control-Allow-Credentials`
+
 * [Security By Default](./docs/stories/security.md#security-by-default)
 
 ## Helpful Links

--- a/Response/HeaderProvider/CorsAllowCredentialsHeaderProvider.php
+++ b/Response/HeaderProvider/CorsAllowCredentialsHeaderProvider.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+namespace Graycore\Cors\Response\HeaderProvider;
+
+use Graycore\Cors\Configuration\CorsConfigurationInterface;
+use Graycore\Cors\Validator\CorsValidatorInterface;
+use Magento\Framework\App\Response\HeaderProvider\AbstractHeaderProvider;
+use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
+
+/**
+ * CorsAllowCredentialsHeaderProvider is responsible for adding the header
+ * Access-Control-Allow-Credentials to a response.
+ * @author    Matthew O'Loughlin <matthew@aligent.com.au>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class CorsAllowCredentialsHeaderProvider extends AbstractHeaderProvider implements HeaderProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $headerName = 'Access-Control-Allow-Credentials';
+
+    /** @var CorsConfigurationInterface */
+    protected $configuration;
+
+    /** @var CorsValidatorInterface */
+    protected $validator;
+
+    /**
+     * CorsAllowHeadersHeaderProvider constructor.
+     *
+     * @param CorsConfigurationInterface $configuration
+     * @param CorsValidatorInterface $validator
+     */
+    public function __construct(CorsConfigurationInterface $configuration, CorsValidatorInterface $validator)
+    {
+        $this->configuration = $configuration;
+        $this->validator = $validator;
+    }
+
+    public function getValue()
+    {
+        return "true";
+    }
+
+    public function canApply()
+    {
+        return $this->validator->originIsValid() && $this->configuration->getAllowCredentials();
+    }
+}

--- a/Response/HeaderProvider/CorsAllowOriginHeaderProvider.php
+++ b/Response/HeaderProvider/CorsAllowOriginHeaderProvider.php
@@ -69,6 +69,10 @@ class CorsAllowOriginHeaderProvider extends AbstractHeaderProvider implements He
 
     public function getValue()
     {
+        if ($this->configuration->getAllowCredentials() && $this->allowedOriginIsWildcard()) {
+            return $this->request->getHeader('Origin');
+        }
+
         return $this->allowedOriginIsWildcard() ? '*' : $this->request->getHeader('Origin');
     }
 }

--- a/Test/Unit/Configuration/GraphQlCorsConfigurationTest.php
+++ b/Test/Unit/Configuration/GraphQlCorsConfigurationTest.php
@@ -62,4 +62,10 @@ class GraphQlCorsConfigurationTest extends \PHPUnit\Framework\TestCase
             $this->configuration->getAllowedOrigins()
         );
     }
+
+    public function testIfAllowCredentialsNotConfiguredItWillReturnFalse()
+    {
+        $this->scopeConfigMock->method('isSetFlag')->willReturn(false);
+        $this->assertEquals(false, $this->configuration->getAllowCredentials());
+    }
 }

--- a/Test/Unit/Configuration/RestCorsConfigurationTest.php
+++ b/Test/Unit/Configuration/RestCorsConfigurationTest.php
@@ -62,4 +62,10 @@ class RestCorsConfigurationTest extends \PHPUnit\Framework\TestCase
             $this->configuration->getAllowedOrigins()
         );
     }
+
+    public function testIfAllowCredentialsNotConfiguredItWillReturnFalse()
+    {
+        $this->scopeConfigMock->method('isSetFlag')->willReturn(false);
+        $this->assertEquals(false, $this->configuration->getAllowCredentials());
+    }
 }

--- a/Test/Unit/HeaderProvider/CorsAllowCredentialsHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowCredentialsHeaderProviderTest.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+namespace Graycore\Cors\Test\Unit\HeaderProvider;
+
+use Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider;
+use Graycore\Cors\Configuration\CorsConfigurationInterface;
+use Graycore\Cors\Validator\CorsValidatorInterface;
+
+/**
+ * Tests that the CORS AllowCredentials header
+ * is properly applied to a response
+ * @author    Matthew O'Loughlin <matthew@aligent.com.au>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class CorsAllowCredentialsHeaderProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** Access-Control-Allow-Credentials Header name */
+    const HEADER_NAME = 'Access-Control-Allow-Credentials';
+
+    /**
+     * @var CorsAllowCredentialsHeaderProvider
+     */
+    protected $provider;
+
+    /**
+     * @var CorsValidatorInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $corsValidatorMock;
+
+    /**
+     * @var CorsConfigurationInterface|\PHPUnit_Framework_MockObject_MockObject
+     */
+    protected $corsConfigurationMock;
+
+    protected function setUp(): void
+    {
+        $this->corsValidatorMock = $this->createMock(CorsValidatorInterface::class);
+        $this->corsConfigurationMock = $this->createMock(CorsConfigurationInterface::class);
+        $this->provider = new CorsAllowCredentialsHeaderProvider(
+            $this->corsConfigurationMock,
+            $this->corsValidatorMock
+        );
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals($this::HEADER_NAME, $this->provider->getName(), 'Wrong header name');
+    }
+
+    public function testNotAppliedIfNotConfigured()
+    {
+        $this->corsConfigurationMock->method('getAllowCredentials')->willReturn(false);
+        $this->corsValidatorMock->method('originIsValid')->willReturn(true);
+        $this->assertEquals(false, $this->provider->canApply(), 'Incorrectly applied header');
+    }
+
+    public function testHeaderAppliedIfConfigured()
+    {
+        $this->corsConfigurationMock->method('getAllowCredentials')->willReturn(true);
+        $this->corsValidatorMock->method('originIsValid')->willReturn(true);
+        $this->assertEquals(true, $this->provider->canApply());
+        $this->assertEquals('true', $this->provider->getValue());
+    }
+}

--- a/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
@@ -123,4 +123,12 @@ class CorsAllowOriginHeaderProviderTest extends \PHPUnit\Framework\TestCase
             ],
         ];
     }
+
+    public function testWildcardOriginWithAllowCredentials()
+    {
+        $this->corsConfigurationMock->method('getAllowedOrigins')->willReturn(["*"]);
+        $this->corsConfigurationMock->method('getAllowCredentials')->willReturn(true);
+        $this->requestMock->method('getHeader')->willReturn("www.example.com");
+        $this->assertEquals("www.example.com", $this->provider->getValue());
+    }
 }

--- a/docs/stories/configuring-the-headers.md
+++ b/docs/stories/configuring-the-headers.md
@@ -7,11 +7,13 @@ We provide several configuration keys for you to configure. The configurations b
 * `web/graphql/cors_allowed_methods` - A comma separated list of the allowed request methods
 * `web/graphql/cors_allowed_headers` - A comma separated list of the allowed response headers
 * `web/graphql/cors_max_age` - The duration that the CORS policy should be cached for.
+* `web/graphql/cors_allow_credentials` - Whether to allow credentials on CORS requests
 
 * `web/api_rest/cors_allowed_origins` - A comma separated list of the origins allowed to the access the REST API
 * `web/api_rest/cors_allowed_methods` - A comma separated list of the allowed request methods
 * `web/api_rest/cors_allowed_headers` - A comma separated list of the allowed response headers
 * `web/api_rest/cors_max_age` - The duration that the CORS policy should be cached for.
+* `web/api_rest/cors_allow_credentials` - Whether to allow credentials on CORS requests
 
 You can add the following to your `app/etc/env.php` to configure the package.
 
@@ -26,13 +28,15 @@ return [
                     'cors_allowed_origins' => 'https://www.graphql.com, https://www.myotherallowedorigin',
                     'cors_allowed_methods' => 'POST, OPTIONS',
                     'cors_allowed_headers' => '',
-                    'cors_max_age' => '86400'
+                    'cors_max_age' => '86400',
+                    'cors_allow_credentials' => 1
                 ],
                 'api_rest' => [
                     'cors_allowed_origins' => 'https://www.restapi.com, https://www.myotherallowedorigin',
                     'cors_allowed_methods' => 'GET, POST, OPTIONS',
                     'cors_allowed_headers' => '',
-                    'cors_max_age' => '86400'
+                    'cors_max_age' => '86400',
+                    'cors_allow_credentials' => 0
                 ]
             ]
         ]
@@ -42,3 +46,4 @@ return [
 ```
 
 > You can also optionally set the `cors_allowed_origins` key to `*` if you want to allow ALL origins access to the resource, but we strongly suggest you [understand the ramifications of this before doing so.](/docs/stories/security.md)
+Note also that the CORS specification disallows a wildcard for Allowed Origins if the `cors_allow_credentials` flag is enabled. If this is the case, the server will instead echo the request Origin back as the Allow-Origin value. 

--- a/etc/config.xml
+++ b/etc/config.xml
@@ -8,12 +8,14 @@
                 <cors_allowed_methods></cors_allowed_methods>
                 <cors_allowed_headers></cors_allowed_headers>
                 <cors_max_age>86400</cors_max_age>
+                <cors_allow_credentials>0</cors_allow_credentials>
             </api_rest>
             <graphql>
                 <cors_allowed_origins></cors_allowed_origins>
                 <cors_allowed_methods></cors_allowed_methods>
                 <cors_allowed_headers></cors_allowed_headers>
                 <cors_max_age>86400</cors_max_age>
+                <cors_allow_credentials>0</cors_allow_credentials>
             </graphql>
         </web>
     </default>

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -11,6 +11,7 @@
                 <item name="CorsAllowOrigin" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowOriginHeaderProvider</item>
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
+                <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
             </argument>
         </arguments>
     </type>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -9,6 +9,7 @@
                 <item name="CorsAllowOrigin" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowOriginHeaderProvider</item>
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
+                <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
* Header provider for Allow-Credentials
* If Allow-Credentials is true; a wildcard is now used to dynamically echo the request origin in the allowed-origin header
* Unit test and documentation updates to include details of the Allow-Credentials functionality