### PR TITLE
chore(release): omit version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,6 @@
     "name": "graycore/magento2-cors",
     "description": "A Magento 2 module that enables CORS on the GraphQL and REST Apis",
     "type": "magento2-module",
-    "version": "1.3.0",
     "license": "MIT",
     "authors": [
         {

--- a/composer.lock
+++ b/composer.lock
@@ -1,10 +1,10 @@
 {
     "_readme": [
         "This file locks the dependencies of your project to a known state",
-        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "fc5a46efcfbc5b604caa3e18d3462f15",
+    "content-hash": "c16ea8906997108368353353dd6a71b7",
     "packages": [
         {
             "name": "colinmollenhour/credis",
@@ -677,7 +677,6 @@
             "dist": {
                 "type": "zip",
                 "url": "https://repo.magento.com/archives/magento/framework/magento-framework-102.0.3.0.zip",
-                "reference": null,
                 "shasum": "32987478cac15913c94f9b9b20935e119b817f5e"
             },
             "require": {
@@ -4485,5 +4484,5 @@
         "ext-gd": "7.2.0",
         "ext-curl": "7.2.0"
     },
-    "version": "1.3.0"
+    "plugin-api-version": "1.1.0"
 }


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

This change results from changes to "standard-version" https://github.com/conventional-changelog/standard-version/releases/tag/v8.0.0

The "standard-version" change derives from the composer package schema, which actually recommends not using the version flag in composer.json. https://getcomposer.org/doc/04-schema.md#version