### PR TITLE
feat(graphql,rest): add support for Vary header with Origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ composer require graycore/magento2-cors
     * `Access-Control-Allow-Credentials`
 
 * [Security By Default](./docs/stories/security.md#security-by-default)
-
+* [Vary: Origin](https://fetch.spec.whatwg.org/#cors-protocol-and-http-caches)
 ## Helpful Links
 * [FAQ](./docs/faq/faqs.md)
     * [Can I configure this from the admin panel?](./docs/faq/faqs.md#can-i-configure-this-from-the-admin-panel)

--- a/Response/HeaderProvider/CorsVaryHeaderProvider.php
+++ b/Response/HeaderProvider/CorsVaryHeaderProvider.php
@@ -37,20 +37,15 @@ class CorsVaryHeaderProvider extends AbstractHeaderProvider implements HeaderPro
     /** @var CorsValidatorInterface */
     protected $validator;
 
-    /** @var Http */
-    protected $request;
-
     /**
      * CorsAllowMethodsHeaderProvider constructor.
      *
      * @param CorsValidatorInterface $validator
      **/
     public function __construct(
-        CorsValidatorInterface $validator,
-        RequestInterface $request
+        CorsValidatorInterface $validator
     ) {
         $this->validator = $validator;
-        $this->request = $request;
     }
 
     /**
@@ -71,6 +66,6 @@ class CorsVaryHeaderProvider extends AbstractHeaderProvider implements HeaderPro
      */
     public function canApply(): bool
     {
-        return $this->validator->originIsValid() && $this->request->getMethod() == "OPTIONS" && $this->getValue();
+        return $this->validator->originIsValid() && $this->getValue();
     }
 }

--- a/Response/HeaderProvider/CorsVaryHeaderProvider.php
+++ b/Response/HeaderProvider/CorsVaryHeaderProvider.php
@@ -1,0 +1,76 @@
+<?php
+
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+
+namespace Graycore\Cors\Response\HeaderProvider;
+
+use Graycore\Cors\Configuration\CorsConfigurationInterface;
+use Graycore\Cors\Validator\CorsValidatorInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Response\HeaderProvider\AbstractHeaderProvider;
+use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
+
+/**
+ * CorsVaryHeaderProvider is responsible for adding the header
+ * Vary Header to a response.
+ * @author    Graycore <damien@graycore.io>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class CorsVaryHeaderProvider extends AbstractHeaderProvider implements HeaderProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $headerName = 'Vary';
+
+    /**
+     * @var string
+     */
+    protected $headerValue = 'Origin';
+
+    /** @var CorsValidatorInterface */
+    protected $validator;
+
+    /** @var Http */
+    protected $request;
+
+    /**
+     * CorsAllowMethodsHeaderProvider constructor.
+     *
+     * @param CorsValidatorInterface $validator
+     **/
+    public function __construct(
+        CorsValidatorInterface $validator,
+        RequestInterface $request
+    ) {
+        $this->validator = $validator;
+        $this->request = $request;
+    }
+
+    /**
+     * We check to see if we can apply the header. Note that, for HTTP,
+     *
+     * ```
+     * Vary: Accept-Encoding
+     * Vary: Origin
+     * ```
+     *
+     * is the same as
+     *
+     * ```
+     * Vary: Accept-Encoding, Origin
+     * ```
+     *
+     * So, we don't bother attempting to merge the two hears into a comma-separated list.
+     */
+    public function canApply(): bool
+    {
+        return $this->validator->originIsValid() && $this->request->getMethod() == "OPTIONS" && $this->getValue();
+    }
+}

--- a/Test/Unit/HeaderProvider/CorsVaryHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsVaryHeaderProviderTest.php
@@ -1,0 +1,83 @@
+<?php
+
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+
+namespace Graycore\Cors\Response\HeaderProvider;
+
+use Graycore\Cors\Configuration\CorsConfigurationInterface;
+use Graycore\Cors\Validator\CorsValidatorInterface;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\Request\Http;
+use Magento\Framework\App\Response\HeaderProvider\AbstractHeaderProvider;
+use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
+use PHPUnit\Framework\MockObject\MockObject;
+
+/**
+ * Tests that the Vary header is properly applied to a response
+ * @author    Graycore <damien@graycore.io>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class CorsVaryHeaderProviderTest extends \PHPUnit\Framework\TestCase
+{
+    /** Vary Header name */
+    const HEADER_NAME = 'Vary';
+
+    /**
+     * Vary Header value
+     */
+    const HEADER_VALUE = 'Origin';
+
+    /**
+     * @var CorsVaryHeaderProvider
+     */
+    protected $provider;
+
+    /**
+     * @var CorsValidatorInterface|MockObject
+     */
+    protected $corsValidatorMock;
+
+    protected function setUp(): void
+    {
+        $this->corsValidatorMock = $this->createMock(CorsValidatorInterface::class);
+        $this->provider = new CorsVaryHeaderProvider($this->corsValidatorMock);
+    }
+
+    public function testGetName()
+    {
+        $this->assertEquals($this::HEADER_NAME, $this->provider->getName(), 'Wrong header name');
+    }
+
+    public function testGetValue()
+    {
+        $this->assertEquals($this::HEADER_VALUE, $this->provider->getValue(), 'Wrong default header value');
+    }
+
+    /**
+     * @dataProvider canApplyDataProvider
+     */
+    public function testCanApply($originResult, $expected)
+    {
+        $this->corsValidatorMock->method('originIsValid')->willReturn($originResult);
+        $this->assertEquals($expected, $this->provider->canApply(), 'Incorrect canApply result');
+    }
+
+    public function canApplyDataProvider()
+    {
+        return [
+            'invalid origin' => [
+                false,
+                false
+            ],
+            'valid origin' => [
+                true,
+                true,
+            ]
+        ];
+    }
+}

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -10,6 +10,7 @@
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
                 <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
+                <item name="CorsVary" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsVaryHeaderProvider</item>
             </argument>
         </arguments>
     </type>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -10,6 +10,7 @@
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
                 <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
+                <item name="CorsVary" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsVaryHeaderProvider</item>
             </argument>
         </arguments>
     </type>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
There is no header set for Vary on Origin.

Fixes: #30 


## What is the new behavior?
There is now a header set.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information