### PR TITLE
testing(graphql,rest): cleanup CORS request tests

### DIFF
--- a/Test/Integration/Response/GraphQlResponseTest.php
+++ b/Test/Integration/Response/GraphQlResponseTest.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
+
 namespace Graycore\Cors\Test\Integration\Response;
 
 use Magento\Framework\App\Response\Http;
@@ -66,7 +68,7 @@ class GraphQlResponseTest extends ControllerTestCase
         $this->assertSame(200, $response->getHttpResponseCode());
     }
 
-     /**
+    /**
      * @magentoConfigFixture default/web/graphql/cors_allowed_origins https://www.example.com
      */
     public function testTheGraphQlResponseContainsCrossOriginHeaders()

--- a/Test/Integration/Response/GraphQlResponseTest.php
+++ b/Test/Integration/Response/GraphQlResponseTest.php
@@ -33,19 +33,6 @@ class GraphQlResponseTest extends ControllerTestCase
     /**
      * @magentoConfigFixture default/web/graphql/cors_allowed_origins https://www.example.com
      */
-    public function testTheGraphQlResponseContainsCrossOriginHeaders()
-    {
-        $this->dispatchToGraphQlApiWithOrigin("https://www.example.com");
-
-        /** @var Http $response */
-        $response = $this->getResponse();
-        $this->assertNotFalse($response->getHeader('Access-Control-Allow-Origin'));
-        $this->assertNotFalse($response->getHeader('Access-Control-Max-Age'));
-    }
-
-    /**
-     * @magentoConfigFixture default/web/graphql/cors_allowed_origins https://www.example.com
-     */
     public function testItdoesNotAddAnyCrossOriginHeadersToATypicalRequest()
     {
         $headers = new Headers();
@@ -67,31 +54,24 @@ class GraphQlResponseTest extends ControllerTestCase
         $this->assertFalse($response->getHeader('Access-Control-Max-Age'));
     }
 
-    public function testTheGraphQlApiWillRespondToAOptionsRequestWithA200Response()
+    /**
+     * @magentoConfigFixture default/web/api_rest/cors_allowed_origins https://www.example.com
+     */
+    public function testTheGraphQlApiWillResponseToACorsRequestWithA200Response()
     {
-        $headers = new Headers();
-        $headers->addHeaderLine('Origin: https://www.example.com');
-        $headers->addHeaderLine('Content-Type: application/json');
-
-        $this->getRequest()->setMethod('OPTIONS')->setHeaders($headers);
-        $this->dispatch('/graphql');
+        $this->dispatchToGraphQlApiWithOrigin('https://www.example.com');
 
         /** @var Http $response */
         $response = $this->getResponse();
         $this->assertSame(200, $response->getHttpResponseCode());
     }
 
-    /**
+     /**
      * @magentoConfigFixture default/web/graphql/cors_allowed_origins https://www.example.com
      */
-    public function testTheGraphQlApiWillRespondToAOptionsRequestWithCorsHeadersOnTheResponse()
+    public function testTheGraphQlResponseContainsCrossOriginHeaders()
     {
-        $headers = new Headers();
-        $headers->addHeaderLine('Origin: https://www.example.com');
-        $headers->addHeaderLine('Content-Type: application/json');
-
-        $this->getRequest()->setMethod('OPTIONS')->setHeaders($headers);
-        $this->dispatch('/graphql');
+        $this->dispatchToGraphQlApiWithOrigin("https://www.example.com");
 
         /** @var Http $response */
         $response = $this->getResponse();

--- a/Test/Integration/Response/WebApiResponseTest.php
+++ b/Test/Integration/Response/WebApiResponseTest.php
@@ -43,7 +43,7 @@ class WebApiResponseTest extends ControllerTestCase
         $headers = new Headers();
         $headers->addHeaderLine('Origin: ' . $origin);
         $headers->addHeaderLine('Content-Type: application/json');
-        $this->getRequest()->setMethod('OPTIONS')->setHeaders($headers);
+        $this->getRequest()->setMethod('GET')->setHeaders($headers);
         ob_start();
         $this->dispatch(self::ENDPOINT);
         $this->getResponse()->sendResponse();
@@ -53,24 +53,8 @@ class WebApiResponseTest extends ControllerTestCase
     /**
      * @magentoConfigFixture default/web/api_rest/cors_allowed_origins https://www.example.com
      */
-    public function testTheRestApiResponseContainsCrossOriginHeaders()
-    {
-        $this->dispatchToRestApiWithOrigin("https://www.example.com");
-
-        /** @var Http $response */
-        $response = $this->getResponse();
-
-        $this->assertNotFalse($response->getHeader('Access-Control-Allow-Origin'));
-        $this->assertNotFalse($response->getHeader('Access-Control-Max-Age'));
-    }
-
-    /**
-     * @magentoConfigFixture default/web/api_rest/cors_allowed_origins https://www.example.com
-     */
     public function testItdoesNotAddAnyCrossOriginHeadersToATypicalRequest()
     {
-        $headers = new Headers();
-        $headers->addHeaderLine('Origin: https://www.example.com');
         $this->dispatchToRestApi();
 
         /** @var Http $response */
@@ -88,14 +72,12 @@ class WebApiResponseTest extends ControllerTestCase
         $this->assertFalse($response->getHeader('Access-Control-Max-Age'));
     }
 
-    public function testTheRestApiWillRespondToAOptionsRequestWithA200Response()
+    /**
+     * @magentoConfigFixture default/web/api_rest/cors_allowed_origins https://www.example.com
+     */
+    public function testTheRestApiWillResponseToACorsRequestWithA200Response()
     {
-        $headers = new Headers();
-        $headers->addHeaderLine('Origin: https://www.example.com');
-        $headers->addHeaderLine('Content-Type: application/json');
-
-        $this->getRequest()->setMethod('OPTIONS')->setHeaders($headers);
-        $this->dispatchToRestApi();
+        $this->dispatchToRestApiWithOrigin('https://www.example.com');
 
         /** @var Http $response */
         $response = $this->getResponse();
@@ -103,20 +85,15 @@ class WebApiResponseTest extends ControllerTestCase
     }
 
     /**
-     * @group fit
      * @magentoConfigFixture default/web/api_rest/cors_allowed_origins https://www.example.com
      */
-    public function testTheRestApiWillRespondToAOptionsRequestWithCorsHeadersOnTheResponse()
+    public function testTheRestApiResponseContainsCrossOriginHeaders()
     {
-        $headers = new Headers();
-        $headers->addHeaderLine('Origin: https://www.example.com');
-        $headers->addHeaderLine('Content-Type: application/json');
-
-        $this->getRequest()->setMethod('POST')->setHeaders($headers);
-        $this->dispatch(self::ENDPOINT);
+        $this->dispatchToRestApiWithOrigin("https://www.example.com");
 
         /** @var Http $response */
         $response = $this->getResponse();
+
         $this->assertNotFalse($response->getHeader('Access-Control-Allow-Origin'));
         $this->assertNotFalse($response->getHeader('Access-Control-Max-Age'));
     }


### PR DESCRIPTION
Previously, the preflight requests were intermingled with the CORS request tests. I've removed the duplicate tests and reworked some of the private functions so that the tests act as expected over time.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[x] Other... Please describe: testing
```