### PR TITLE
feat(graphql, rest): add support for access-control-expose-headers

### DIFF
--- a/Configuration/CorsConfigurationInterface.php
+++ b/Configuration/CorsConfigurationInterface.php
@@ -40,4 +40,9 @@ interface CorsConfigurationInterface
      * @return bool
      */
     public function getAllowCredentials(): bool;
+
+    /**
+     * @return string[];
+     */
+    public function getExposedHeaders(): array;
 }

--- a/Configuration/GraphQl/CorsConfiguration.php
+++ b/Configuration/GraphQl/CorsConfiguration.php
@@ -27,6 +27,8 @@ class CorsConfiguration implements CorsConfigurationInterface
 
     const XML_PATH_GRAPHQL_CORS_MAX_AGE = 'web/graphql/cors_max_age';
 
+    const XML_PATH_GRAPHQL_CORS_EXPOSE_HEADERS = 'web/graphql/cors_expose_headers';
+
     const XML_PATH_GRAPHQL_CORS_CREDENTIALS = 'web/graphql/cors_allow_credentials';
 
     /** @var ScopeConfigInterface */
@@ -93,5 +95,15 @@ class CorsConfiguration implements CorsConfigurationInterface
     public function getAllowCredentials(): bool
     {
         return $this->scopeConfig->isSetFlag(self::XML_PATH_GRAPHQL_CORS_CREDENTIALS);
+    }
+
+    /**
+     * @return string[];
+     */
+    public function getExposedHeaders(): array
+    {
+        return $this->cleaner->processDelimitedString(
+            $this->scopeConfig->getValue(self::XML_PATH_GRAPHQL_CORS_EXPOSE_HEADERS)
+        );
     }
 }

--- a/Configuration/Rest/CorsConfiguration.php
+++ b/Configuration/Rest/CorsConfiguration.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
+
 namespace Graycore\Cors\Configuration\Rest;
 
 use Graycore\Cors\Configuration\ConfigurationCleaner;
@@ -26,6 +28,8 @@ class CorsConfiguration implements CorsConfigurationInterface
     const XML_PATH_WEBAPI_REST_CORS_HEADERS = 'web/api_rest/cors_allowed_headers';
 
     const XML_PATH_WEBAPI_REST_CORS_MAX_AGE = 'web/api_rest/cors_max_age';
+
+    const XML_PATH_WEBAPI_REST_CORS_EXPOSE_HEADERS = 'web/api_rest/cors_expose_headers';
 
     const XML_PATH_REST_CORS_CREDENTIALS = 'web/api_rest/cors_allow_credentials';
 
@@ -93,5 +97,15 @@ class CorsConfiguration implements CorsConfigurationInterface
     public function getAllowCredentials(): bool
     {
         return $this->scopeConfig->isSetFlag(self::XML_PATH_REST_CORS_CREDENTIALS);
+    }
+
+    /**
+     * @return string[];
+     */
+    public function getExposedHeaders(): array
+    {
+        return $this->cleaner->processDelimitedString(
+            $this->scopeConfig->getValue(self::XML_PATH_WEBAPI_REST_CORS_EXPOSE_HEADERS)
+        );
     }
 }

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ composer require graycore/magento2-cors
     * `Access-Control-Allow-Methods`
     * `Access-Control-Allow-Headers`
     * `Access-Control-Max-Age`
+    * `Access-Control-Expose-Headers`
     * `Access-Control-Allow-Credentials`
 
 * [Security By Default](./docs/stories/security.md#security-by-default)

--- a/Response/HeaderProvider/CorsExposeHeadersProvider.php
+++ b/Response/HeaderProvider/CorsExposeHeadersProvider.php
@@ -1,0 +1,62 @@
+<?php
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+namespace Graycore\Cors\Response\HeaderProvider;
+
+use Graycore\Cors\Configuration\CorsConfigurationInterface;
+use Graycore\Cors\Validator\CorsValidatorInterface;
+use Magento\Framework\App\Response\HeaderProvider\AbstractHeaderProvider;
+use Magento\Framework\App\Response\HeaderProvider\HeaderProviderInterface;
+
+/**
+ * CorsExposeHeadersProvider is responsible for adding the header
+ * Access-Control-Expose-Headers to a response.
+ * @author    Graycore <damien@graycore.io>
+ * @copyright Graycore, LLC (https://www.graycore.io/)
+ * @license   MIT https://github.com/graycoreio/magento2-cors/license
+ * @link      https://github.com/graycoreio/magento2-cors
+ */
+class CorsExposeHeadersProvider extends AbstractHeaderProvider implements HeaderProviderInterface
+{
+    /**
+     * @var string
+     */
+    protected $headerName = 'Access-Control-Expose-Headers';
+
+    /**
+     * @var string
+     */
+    protected $headerValue = '';
+
+    /** @var CorsConfigurationInterface */
+    protected $configuration;
+
+    /** @var CorsValidatorInterface */
+    protected $validator;
+
+    /**
+     * CorsAllowMethodsHeaderProvider constructor.
+     *
+     * @param CorsConfigurationInterface $configuration
+     * @param CorsValidatorInterface $validator
+     **/
+    public function __construct(CorsConfigurationInterface $configuration, CorsValidatorInterface $validator)
+    {
+        $this->configuration = $configuration;
+        $this->validator = $validator;
+    }
+
+    public function getValue()
+    {
+        return $this->configuration->getExposedHeaders()
+        ? implode(',', $this->configuration->getExposedHeaders())
+        : $this->headerValue;
+    }
+
+    public function canApply(): bool
+    {
+        return $this->validator->originIsValid() && $this->getValue();
+    }
+}

--- a/docs/stories/configuring-the-headers.md
+++ b/docs/stories/configuring-the-headers.md
@@ -7,12 +7,14 @@ We provide several configuration keys for you to configure. The configurations b
 * `web/graphql/cors_allowed_methods` - A comma separated list of the allowed request methods
 * `web/graphql/cors_allowed_headers` - A comma separated list of the allowed response headers
 * `web/graphql/cors_max_age` - The duration that the CORS policy should be cached for.
+* `web/graphql/cors_expose_headers` - A comma separated list that indicates which headers can be exposed as part of the response.
 * `web/graphql/cors_allow_credentials` - Whether to allow credentials on CORS requests
 
 * `web/api_rest/cors_allowed_origins` - A comma separated list of the origins allowed to the access the REST API
 * `web/api_rest/cors_allowed_methods` - A comma separated list of the allowed request methods
 * `web/api_rest/cors_allowed_headers` - A comma separated list of the allowed response headers
 * `web/api_rest/cors_max_age` - The duration that the CORS policy should be cached for.
+* `web/api_rest/cors_expose_headers` - A comma separated list that indicates which headers can be exposed as part of the response.
 * `web/api_rest/cors_allow_credentials` - Whether to allow credentials on CORS requests
 
 You can add the following to your `app/etc/env.php` to configure the package.

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -9,6 +9,7 @@
                 <item name="CorsAllowOrigin" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowOriginHeaderProvider</item>
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
+                <item name="CorsExposeHeaders" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsExposeHeadersProvider</item>
                 <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
             </argument>
         </arguments>

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -9,6 +9,7 @@
                 <item name="CorsAllowOrigin" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowOriginHeaderProvider</item>
                 <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
                 <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
+                <item name="CorsExposeHeaders" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsExposeHeadersProvider</item>
                 <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
             </argument>
         </arguments>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we don't allow users to configure the exposed headers on the response.

Fixes: #6 


## What is the new behavior?
Users can now decide what headers are exposed on the response.

## Does this PR introduce a breaking change?
```
[ ] Yes
[ ] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information