### PR TITLE
feat(graphql, rest): apply certain headers only to preflight requests

### DIFF
--- a/Response/HeaderProvider/CorsAllowHeadersHeaderProvider.php
+++ b/Response/HeaderProvider/CorsAllowHeadersHeaderProvider.php
@@ -57,6 +57,6 @@ class CorsAllowHeadersHeaderProvider extends AbstractHeaderProvider implements H
 
     public function canApply()
     {
-        return $this->validator->originIsValid() && $this->getValue();
+        return $this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
     }
 }

--- a/Response/HeaderProvider/CorsAllowMethodsHeaderProvider.php
+++ b/Response/HeaderProvider/CorsAllowMethodsHeaderProvider.php
@@ -57,6 +57,6 @@ class CorsAllowMethodsHeaderProvider extends AbstractHeaderProvider implements H
 
     public function canApply()
     {
-        return $this->validator->originIsValid() && $this->getValue();
+        return $this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
     }
 }

--- a/Response/HeaderProvider/CorsExposeHeadersProvider.php
+++ b/Response/HeaderProvider/CorsExposeHeadersProvider.php
@@ -57,6 +57,6 @@ class CorsExposeHeadersProvider extends AbstractHeaderProvider implements Header
 
     public function canApply(): bool
     {
-        return $this->validator->originIsValid() && $this->getValue();
+        return $this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
     }
 }

--- a/Response/HeaderProvider/CorsMaxAgeHeaderProvider.php
+++ b/Response/HeaderProvider/CorsMaxAgeHeaderProvider.php
@@ -55,6 +55,6 @@ class CorsMaxAgeHeaderProvider extends AbstractHeaderProvider implements HeaderP
 
     public function canApply(): bool
     {
-        return $this->validator->originIsValid() && $this->getValue();
+        return $this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
     }
 }

--- a/Test/Integration/Response/GraphQlResponseTest.php
+++ b/Test/Integration/Response/GraphQlResponseTest.php
@@ -78,6 +78,5 @@ class GraphQlResponseTest extends ControllerTestCase
         /** @var Http $response */
         $response = $this->getResponse();
         $this->assertNotFalse($response->getHeader('Access-Control-Allow-Origin'));
-        $this->assertNotFalse($response->getHeader('Access-Control-Max-Age'));
     }
 }

--- a/Test/Integration/Response/WebApiResponseTest.php
+++ b/Test/Integration/Response/WebApiResponseTest.php
@@ -95,6 +95,5 @@ class WebApiResponseTest extends ControllerTestCase
         $response = $this->getResponse();
 
         $this->assertNotFalse($response->getHeader('Access-Control-Allow-Origin'));
-        $this->assertNotFalse($response->getHeader('Access-Control-Max-Age'));
     }
 }

--- a/Test/Unit/HeaderProvider/CorsAllowHeadersHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowHeadersHeaderProviderTest.php
@@ -83,28 +83,50 @@ class CorsAllowHeadersHeaderProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider canApplyDataProvider
      */
-    public function testCanApply($headers, $originResult, $expected)
+    public function testCanApply($headers, $originResult, $isPreflight, $expected)
     {
         $this->corsConfigurationMock->method('getAllowedHeaders')->willReturn($headers);
         $this->corsValidatorMock->method('originIsValid')->willReturn($originResult);
+        $this->corsValidatorMock->method('isPreflightRequest')->willReturn($isPreflight);
         $this->assertEquals($expected, $this->provider->canApply(), 'Incorrect canApply result');
     }
 
     public function canApplyDataProvider()
     {
         return [
-            'invalid origin' => [
+            'invalid origin, cors request' => [
                 ['My-Valid-Header', 'My-Other-Valid-Header'],
                 false,
                 false,
+                false,
             ],
-            'valid origin without configured headers' => [
-                [],
+            'invalid origin, preflight request' => [
+                ['My-Valid-Header', 'My-Other-Valid-Header'],
+                false,
                 true,
                 false,
             ],
-            'valid origin with header configuration' => [
+            'valid origin, cors request without configured headers' => [
+                [],
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request without configured headers' => [
+                [],
+                true,
+                true,
+                false,
+            ],
+            'valid origin, cors request with header configuration' => [
                 ['My-Valid-Header', 'My-Other-Valid-Header'],
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request with header configuration' => [
+                ['My-Valid-Header', 'My-Other-Valid-Header'],
+                true,
                 true,
                 true,
             ],

--- a/Test/Unit/HeaderProvider/CorsAllowMethodsHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowMethodsHeaderProviderTest.php
@@ -83,28 +83,50 @@ class CorsAllowMethodsHeaderProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider canApplyDataProvider
      */
-    public function testCanApply($methods, $originResult, $expected)
+    public function testCanApply($methods, $originResult, $isPreflightRequest, $expected)
     {
         $this->corsConfigurationMock->method('getAllowedMethods')->willReturn($methods);
         $this->corsValidatorMock->method('originIsValid')->willReturn($originResult);
+        $this->corsValidatorMock->method('isPreflightRequest')->willReturn($isPreflightRequest);
         $this->assertEquals($expected, $this->provider->canApply(), 'Incorrect canApply result');
     }
 
     public function canApplyDataProvider()
     {
         return [
-            'invalid origin' => [
+            'invalid origin, cors request' => [
                 ['GET', 'POST', 'OPTIONS'],
                 false,
                 false,
+                false,
             ],
-            'valid origin without configured methods' => [
+            'invalid origin, preflight request' => [
+                ['GET', 'POST', 'OPTIONS'],
+                false,
+                true,
+                false,
+            ],
+            'valid origin, cors request, without configured methods' => [
+                [],
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request, without configured methods' => [
                 [],
                 true,
                 true,
+                true,
             ],
-            'valid origin with configured methods' => [
+            'valid origin, cors request, with configured methods' => [
                 ['GET', 'POST', 'OPTIONS'],
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request, with configured methods' => [
+                ['GET', 'POST', 'OPTIONS'],
+                true,
                 true,
                 true,
             ],

--- a/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
+
 namespace Graycore\Cors\Test\Unit\HeaderProvider;
 
 use Graycore\Cors\Configuration\CorsConfigurationInterface;
@@ -12,7 +14,7 @@ use Graycore\Cors\Validator\CorsValidatorInterface;
 
 /**
  * Tests that the CORS AllowOrigin header is properly applied to a response
- * 
+ *
  * @author    Graycore <damien@graycore.io>
  * @copyright Graycore, LLC (https://www.graycore.io/)
  * @license   MIT https://github.com/graycoreio/magento2-cors/license

--- a/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsAllowOriginHeaderProviderTest.php
@@ -11,8 +11,8 @@ use Magento\Framework\App\Request\Http;
 use Graycore\Cors\Validator\CorsValidatorInterface;
 
 /**
- * Tests that the CORS AllowOrigin header
- * is properly applied to a response
+ * Tests that the CORS AllowOrigin header is properly applied to a response
+ * 
  * @author    Graycore <damien@graycore.io>
  * @copyright Graycore, LLC (https://www.graycore.io/)
  * @license   MIT https://github.com/graycoreio/magento2-cors/license

--- a/Test/Unit/HeaderProvider/CorsMaxAgeHeaderProviderTest.php
+++ b/Test/Unit/HeaderProvider/CorsMaxAgeHeaderProviderTest.php
@@ -63,33 +63,62 @@ class CorsMaxAgeHeaderProviderTest extends \PHPUnit\Framework\TestCase
     /**
      * @dataProvider canApplyDataProvider
      */
-    public function testCanApply($maxAge, $originResult, $expected)
+    public function testCanApply($maxAge, $originResult, $isPreflightRequest, $expected)
     {
         $this->corsConfigurationMock->method('getMaxAge')->willReturn($maxAge);
         $this->corsValidatorMock->method('originIsValid')->willReturn($originResult);
+        $this->corsValidatorMock->method('isPreflightRequest')->willReturn($isPreflightRequest);
         $this->assertEquals($expected, $this->provider->canApply(), 'Incorrect canApply result');
     }
 
     public function canApplyDataProvider()
     {
         return [
-            'invalid origin' => [
+            'invalid origin, cors request' => [
                 '1000',
                 false,
                 false,
+                false,
             ],
-            'valid origin with null configured maxAge' => [
+            'invalid origin, preflight request' => [
+                '1000',
+                false,
+                true,
+                false,
+            ],
+            'valid origin, cors request with null configured maxAge' => [
+                null,
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request with null configured maxAge' => [
                 null,
                 true,
                 true,
+                true,
             ],
-            'valid origin with empty configured maxAge' => [
+            'valid origin, cors request with empty configured maxAge' => [
+                '',
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request with empty configured maxAge' => [
                 '',
                 true,
                 true,
+                true,
             ],
-            'valid origin with configured age' => [
+            'valid origin, cors request with configured age' => [
                 '86400',
+                true,
+                false,
+                false,
+            ],
+            'valid origin, preflight request with configured age' => [
+                '86400',
+                true,
                 true,
                 true,
             ],


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, we apply headers to the CORS request that we should only apply to the preflight.

Fixes: N/A

## What is the new behavior?
We apply the right headers to the right requests.


## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

## Other information