### PR TITLE
feat(rest): extend REST request to allow OPTIONS without error

### DIFF
--- a/Request/RestRequest.php
+++ b/Request/RestRequest.php
@@ -1,0 +1,31 @@
+<?php
+/**
+ * @copyright  Copyright 2017 SplashLab
+ */
+/**
+ * Copyright © Graycore, LLC. All rights reserved.
+ * See LICENSE.md for details.
+ */
+namespace Graycore\Cors\Request;
+
+use Magento\Framework\Webapi\Request;
+use Magento\Framework\Exception\InputException;
+
+class RestRequest
+{
+    /**
+     * Triggers before original dispatch
+     *
+     * @param Request $subject
+     * @return void
+     * @throws InputException
+     */
+    public function aroundGetHttpMethod(
+        Request $subject
+    ) {
+        if (!$subject->isGet() && !$subject->isPost() && !$subject->isPut() && !$subject->isDelete() && !$subject->isOptions()) {
+            throw new InputException(__('Request method is invalid.'));
+        }
+        return $subject->getMethod();
+    }
+}

--- a/Request/RestRequest.php
+++ b/Request/RestRequest.php
@@ -1,11 +1,13 @@
 <?php
+
 /**
- * @copyright  Copyright 2017 SplashLab
+ * @copyright Copyright 2017 SplashLab
  */
 /**
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
+
 namespace Graycore\Cors\Request;
 
 use Magento\Framework\Webapi\Request;
@@ -16,14 +18,19 @@ class RestRequest
     /**
      * Triggers before original dispatch
      *
-     * @param Request $subject
+     * @param  Request $subject
      * @return void
      * @throws InputException
      */
     public function aroundGetHttpMethod(
         Request $subject
     ) {
-        if (!$subject->isGet() && !$subject->isPost() && !$subject->isPut() && !$subject->isDelete() && !$subject->isOptions()) {
+        if (!$subject->isGet()
+            && !$subject->isPost()
+            && !$subject->isPut()
+            && !$subject->isDelete()
+            && !$subject->isOptions()
+        ) {
             throw new InputException(__('Request method is invalid.'));
         }
         return $subject->getMethod();

--- a/etc/webapi_rest/di.xml
+++ b/etc/webapi_rest/di.xml
@@ -18,6 +18,9 @@
     <type name="Magento\Webapi\Controller\Rest">
         <plugin name="graycoreCorsPreflightHandlerRest" type="Graycore\Cors\Response\Preflight\Rest\PreflightRequestHandler" />
     </type>
+    <type name="Magento\Framework\Webapi\Rest\Request">
+        <plugin name="cors_request_options" type="Graycore\Cors\Request\RestRequest" />
+    </type>
     <type name="Magento\Framework\Webapi\Rest\Response">
         <plugin name="genericWebApiHeaderPlugin" type="Graycore\Cors\Response\HeaderManager"/>
     </type>


### PR DESCRIPTION
Co-authored-by: Evan Johnson <thaddeusmt@gmail.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Currently, some requests may fail if another plugin attempts to call "getHttpMethod" on REST requests that are options. 

Fixes: #54 


## What is the new behavior?
To address, we expand the `Webapi\Rest\Request` to allow for Options requests.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```
