### PR TITLE
feat(graphql,rest): add faster CORS headers

### DIFF
--- a/Controller/NoopController.php
+++ b/Controller/NoopController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Graycore\Cors\Controller;
+
+use Graycore\Cors\Response\HeaderManager;
+use Magento\Framework\App\RequestInterface;
+use Magento\Framework\App\ResponseInterface;
+use Magento\Framework\App\Response\Http as ResponseHttp;
+
+class NoopController
+{
+
+    /**
+     * @var HeaderManager
+     */
+    private $_headerManager;
+
+    /**
+     * @var ResponseHttp
+     */
+    private $_response;
+
+    public function __construct(
+        HeaderManager $headerManager,
+        ResponseHttp $response
+    ) {
+        $this->_headerManager = $headerManager;
+        $this->_response = $response;
+    }
+
+    /**
+     * Dispatch application action
+     *
+     * @param RequestInterface $request
+     * @return ResponseInterface
+     */
+    public function dispatch(RequestInterface $request)
+    {
+        $this->_headerManager->applyHeaders($this->_response);
+        return $this->_response;
+    }
+}

--- a/Plugin/FastLauncher.php
+++ b/Plugin/FastLauncher.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Graycore\Cors\Plugin;
+
+use Magento\Framework\App\AreaList;
+use Magento\Framework\App\State;
+use Magento\Framework\ObjectManager\ConfigLoaderInterface;
+use Magento\Framework\ObjectManagerInterface;
+use Magento\Framework\App\Request\Http as RequestHttp;
+
+class FastLauncher
+{
+    /**
+     * @var ObjectManagerInterface
+     */
+    private $_objectManager;
+
+    /**
+     * @var AreaList
+     */
+    private $_areaList;
+
+    /**
+     * @var ConfigLoaderInterface
+     */
+    private $_configLoader;
+
+    /**
+     * @var State
+     */
+    private $_state;
+
+    /**
+     * @var RequestHttp
+     */
+    private $_request;
+
+    /**
+     * @param ObjectManagerInterface $objectManager
+     * @param AreaList $areaList
+     * @param ConfigLoaderInterface $configLoader
+     * @param State $state
+     */
+    public function __construct(
+        ObjectManagerInterface $objectManager,
+        AreaList $areaList,
+        RequestHttp $request,
+        ConfigLoaderInterface $configLoader,
+        State $state
+    ) {
+        $this->_objectManager = $objectManager;
+        $this->_areaList = $areaList;
+        $this->_configLoader = $configLoader;
+        $this->_state = $state;
+        $this->_request = $request;
+    }
+
+    public function aroundLaunch(\Magento\Framework\AppInterface $subject, callable $proceed)
+    {
+        if ($this->_request->getMethod() === RequestHttp::METHOD_OPTIONS) {
+            $areaCode = $this->_areaList->getCodeByFrontName($this->_request->getFrontName());
+            $this->_state->setAreaCode($areaCode);
+            $this->_objectManager->configure($this->_configLoader->load($areaCode));
+            /** @var \Graycore\Cors\Controller\NoopController::class */
+            $controller = $this->_objectManager->get(\Graycore\Cors\Controller\NoopController::class);
+            $response = $controller->dispatch($this->_request);
+            return $response;
+        };
+
+        return $proceed();
+    }
+}

--- a/docs/upgrading/guide.md
+++ b/docs/upgrading/guide.md
@@ -1,3 +1,16 @@
 # Upgrade Guide
 
 When we make breaking changes, we will post the breaking changes here.
+
+## v1.* to v2.0
+
+The layer in which we compute whether or not an incoming preflight request receives CORS headers has changed in v2.0.0. Previously, we leveraged a plugin around the relevant native Magento 2 Controller (webapi_rest/graphql) and as a result, we incurred significant overhead from Magento code when computing CORS headers. 
+
+In v2.0, we no longer incur this overhead by adding a plugin around application launch and creating our own custom controller. It is **very possible** that we broke expectations of anything that plugs-in around this plugin or adds additional CORS headers other than our own. 
+
+For 99.99% of GraphQl/Rest API deployments, the API is used sessionlessly. As such, we can take the opportunity to improve performance for the majority at the expense of the minority. If this breaks your codebase, please submit an issue and we will see what can be done to remedy your specific use-case.
+
+In theory, most dependents simply need to upgrade to v2.0 and there are no breaking changes. 
+
+**However,** if you were expecting to use the native GraphQl/REST controller when computing CORS headers (and everything else that entails - like having a Magento session, for example) that guarantee is no-longer provided.
+

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,0 +1,5 @@
+<config>
+    <type name="Magento\Framework\AppInterface">
+        <plugin name="graycoreCorsLauncher" type="Graycore\Cors\Plugin\FastLauncher"/>
+    </type>
+</config>

--- a/etc/graphql/di.xml
+++ b/etc/graphql/di.xml
@@ -15,6 +15,19 @@
             </argument>
         </arguments>
     </type>
+    <type name="Graycore\Cors\Response\HeaderManager">
+        <arguments>
+            <argument name="headerProviderList" xsi:type="array">
+                <item name="CorsAllowHeaders" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowHeadersHeaderProvider</item>
+                <item name="CorsAllowOrigin" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowOriginHeaderProvider</item>
+                <item name="CorsAllowMethods" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowMethodsHeaderProvider</item>
+                <item name="CorsMaxAge" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsMaxAgeHeaderProvider</item>
+                <item name="CorsExposeHeaders" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsExposeHeadersProvider</item>
+                <item name="CorsAllowCredentials" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsAllowCredentialsHeaderProvider</item>
+                <item name="CorsVary" xsi:type="object">Graycore\Cors\Response\HeaderProvider\CorsVaryHeaderProvider</item>
+            </argument>
+        </arguments>
+    </type>
     <type name="Magento\GraphQl\Controller\GraphQl">
         <plugin name="graycoreCorsPreflightHandlerGraphQl" type="Graycore\Cors\Response\Preflight\GraphQl\PreflightRequestHandler" />
     </type>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[x] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
Fixes: #65 


## What is the new behavior?
The layer in which we compute whether or not an incoming preflight request receives CORS headers has changed. Previously, we leveraged a plugin around the relevant native Magento 2 Controller (webapi_rest/graphql) and as a result, we incurred significant overhead from Magento code when computing CORS headers. 

In the new code we no longer incur this overhead by adding a plugin around application launch and creating our own custom controller. It is **very possible** that we broke expectations of anything that plugs-in around this plugin or adds additional CORS headers other than our own. 

For 99.99% of GraphQl/Rest API deployments, the API is used sessionlessly. As such, we can take the opportunity to improve performance for the majority at the expense of the minority. If this breaks your codebase, please submit an issue and we will see what can be done to remedy your specific use-case.

In theory, most dependents simply need to upgrade and there are no breaking changes. 

**However,** if you were expecting to use the native GraphQl/REST controller when computing CORS headers (and everything else that entails - like having a Magento session, for example) that guarantee is no-longer provided.


## Does this PR introduce a breaking change?
```
[x] Yes
[ ] No
```

## Other information