### PR TITLE
Better PHP8.1 support

### DIFF
--- a/Configuration/ConfigurationCleaner.php
+++ b/Configuration/ConfigurationCleaner.php
@@ -18,6 +18,9 @@ class ConfigurationCleaner
     
     public function processDelimitedString($string, $delimiter = ',')
     {
+        if(empty($string)) {
+            return [];
+        }
         $configuration = explode($delimiter, $string);
         $cleanedConfiguration = [];
         $cleanedConfiguration = array_map(


### PR DESCRIPTION
PHP8.1 throws a warning when `$string` is null, if it is any form of empty we can immediately return with an empty array.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PHP8.1 throws a warning when `$string` is null, if it is any form of empty we can immediately return with an empty array.

Fixes: N/A


## What is the new behavior?
The module short circuits with an empty array if `$string` is empty

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information