### PR TITLE
feat: add Magento v2.4.4 and PHP8.1 support

### DIFF
--- a/Configuration/ConfigurationCleaner.php
+++ b/Configuration/ConfigurationCleaner.php
@@ -18,6 +18,9 @@ class ConfigurationCleaner
     
     public function processDelimitedString($string, $delimiter = ',')
     {
+        if(empty($string)) {
+            return [];
+        }
         $configuration = explode($delimiter, $string);
         $cleanedConfiguration = [];
         $cleanedConfiguration = array_map(

--- a/Configuration/ConfigurationCleaner.php
+++ b/Configuration/ConfigurationCleaner.php
@@ -1,8 +1,10 @@
 <?php
+
 /**
  * Copyright © Graycore, LLC. All rights reserved.
  * See LICENSE.md for details.
  */
+
 namespace Graycore\Cors\Configuration;
 
 /**
@@ -15,10 +17,10 @@ namespace Graycore\Cors\Configuration;
  */
 class ConfigurationCleaner
 {
-    
+
     public function processDelimitedString($string, $delimiter = ',')
     {
-        if(empty($string)) {
+        if (empty($string)) {
             return [];
         }
         $configuration = explode($delimiter, $string);

--- a/ci/phpunit.xml
+++ b/ci/phpunit.xml
@@ -1,15 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright © Reach Digital (https://www.reachdigital.io/)
-  ~ See LICENSE.txt for license details.
-  -->
+/**
+ * Copyright © Magento, Inc. All rights reserved.
+ * See COPYING.txt for license details.
+ */
+-->
 <phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xsi:noNamespaceSchemaLocation="http://schema.phpunit.de/6.2/phpunit.xsd"
+         xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd"
          colors="true"
+         columns="max"
          beStrictAboutTestsThatDoNotTestAnything="false"
          bootstrap="./framework/bootstrap.php"
-         stderr="true"
->
+         stderr="true">
     <!-- Test suites definition -->
     <testsuites>
         <testsuite name="Graycore_Magento2Cors">
@@ -20,7 +22,7 @@
     <php>
         <includePath>.</includePath>
         <includePath>testsuite</includePath>
-        <ini name="date.timezone" value="Europe/Amsterdam"/>
+        <ini name="date.timezone" value="America/Los_Angeles"/>
         <ini name="xdebug.max_nesting_level" value="200"/>
         <!-- Local XML configuration file ('.dist' extension will be added, if the specified file doesn't exist) -->
         <const name="TESTS_INSTALL_CONFIG_FILE" value="etc/install-config-mysql.php"/>
@@ -31,22 +33,20 @@
         <!-- Semicolon-separated 'glob' patterns, that match global XML configuration files -->
         <const name="TESTS_GLOBAL_CONFIG_DIR" value="../../../app/etc"/>
         <!-- Whether to cleanup the application before running tests or not -->
-        <const name="TESTS_CLEANUP" value="disabled"/>
+        <const name="TESTS_CLEANUP" value="enabled"/>
         <!-- Memory usage and estimated leaks thresholds -->
         <!--<const name="TESTS_MEM_USAGE_LIMIT" value="1024M"/>-->
         <const name="TESTS_MEM_LEAK_LIMIT" value=""/>
-        <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
-        <!--<const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>-->
         <!-- Path to Percona Toolkit bin directory -->
         <!--<const name="PERCONA_TOOLKIT_BIN_DIR" value=""/>-->
         <!-- CSV Profiler Output file -->
-        <const name="TESTS_PROFILER_FILE" value="profiler.csv"/>
+        <!--<const name="TESTS_PROFILER_FILE" value="profiler.csv"/>-->
         <!-- Bamboo compatible CSV Profiler Output file name -->
         <!--<const name="TESTS_BAMBOO_PROFILER_FILE" value="profiler.csv"/>-->
         <!-- Metrics for Bamboo Profiler Output in PHP file that returns array -->
         <!--<const name="TESTS_BAMBOO_PROFILER_METRICS_FILE" value="../../build/profiler_metrics.php"/>-->
         <!-- Whether to output all CLI commands executed by the bootstrap and tests -->
-        <const name="TESTS_EXTRA_VERBOSE_LOG" value="0"/>
+        <const name="TESTS_EXTRA_VERBOSE_LOG" value="1"/>
         <!-- Magento mode for tests execution. Possible values are "default", "developer" and "production". -->
         <const name="TESTS_MAGENTO_MODE" value="developer"/>
         <!-- Minimum error log level to listen for. Possible values: -1 ignore all errors, and level constants form http://tools.ietf.org/html/rfc5424 standard -->
@@ -54,6 +54,12 @@
         <!-- Connection parameters for MongoDB library tests -->
         <!--<const name="MONGODB_CONNECTION_STRING" value="mongodb://localhost:27017"/>-->
         <!--<const name="MONGODB_DATABASE_NAME" value="magento_integration_tests"/>-->
+        <!-- Connection parameters for RabbitMQ tests -->
+        <!--<const name="RABBITMQ_MANAGEMENT_PROTOCOL" value="https"/>-->
+        <!--<const name="RABBITMQ_MANAGEMENT_PORT" value="15672"/>-->
+        <!--<const name="RABBITMQ_VIRTUALHOST" value="/"/>-->
+        <!--<const name="TESTS_PARALLEL_RUN" value="1"/>-->
+        <const name="USE_OVERRIDE_CONFIG" value="enabled"/>
     </php>
     <!-- Test listeners -->
     <listeners>


### PR DESCRIPTION
PHP8.1 throws a warning when `$string` is null, if it is any form of empty we can immediately return with an empty array.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->
PHP8.1 throws a warning when `$string` is null, if it is any form of empty we can immediately return with an empty array.

Fixes: N/A


## What is the new behavior?
The module short circuits with an empty array if `$string` is empty

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information