### PR TITLE
fix: wrong di.xml configuration - missing noNamespaceSchemaLocation

### DIFF
--- a/etc/di.xml
+++ b/etc/di.xml
@@ -1,4 +1,5 @@
-<config>
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:ObjectManager/etc/config.xsd">
     <type name="Magento\Framework\AppInterface">
         <plugin name="graycoreCorsLauncher" type="Graycore\Cors\Plugin\FastLauncher"/>
     </type>


### PR DESCRIPTION
fix: wrong di.xml configuration - missing noNamespaceSchemaLocation and xmlns:xsi

This caused static tests for M2 fail and when project is using automated testing for the modules it is inconvenient to exclude this module only. By this change, static tests will pass for this module.

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit (checked, but still not sure)
- [x] Tests for the changes have been added (for bug fixes / features) (Not applicable)
- [x] Docs have been added / updated (for bug fixes / features) (Not applicable)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

- `php -d memory_limit=-1 ../../../../code/vendor/bin/phpunit -c phpunit.xml --testsuite "Code Integrity Tests" --filter "SchemaTest"`

Output from the command without this change:

```
PHPUnit 9.5.22 #StandWithUkraine

There was 1 failure:

1) Magento\Test\Integrity\Xml\SchemaTest::testXmlFiles
Passed: 2980, Failed: 1, Incomplete: 0, Skipped: 0.
Data set: /vendor/graycore/magento2-cors/etc/di.xml
The XML file at /app/vendor/graycore/magento2-cors/etc/di.xml does not have a schema properly defined.  It should have a xsi:noNamespaceSchemaLocation attribute defined with a URN path.  E.g. xsi:noNamespaceSchemaLocation="urn:magento:framework:Relative_Path/something.xsd"
Failed asserting that actual size 0 matches expected size 2.
/app/dev/tests/static/testsuite/Magento/Test/Integrity/Xml/SchemaTest.php:30
/app/vendor/magento/framework/App/Utility/AggregateInvoker.php:57
/app/dev/tests/static/testsuite/Magento/Test/Integrity/Xml/SchemaTest.php:16

/app/vendor/magento/framework/App/Utility/AggregateInvoker.php:116
/app/vendor/magento/framework/App/Utility/AggregateInvoker.php:71
/app/dev/tests/static/testsuite/Magento/Test/Integrity/Xml/SchemaTest.php:16

FAILURES!
Tests: 1, Assertions: 8943, Failures: 1.
```


## What is the new behavior?

Desired output (with this change):

```
PHPUnit 9.5.22 #StandWithUkraine

.

Time: 00:05.666, Memory: 24.00 MB

OK (1 test, 8943 assertions)
```

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information