### PR TITLE
fix: `Access-Control-Expose-Headers` set on preflight

### DIFF
--- a/Response/HeaderProvider/CorsExposeHeadersProvider.php
+++ b/Response/HeaderProvider/CorsExposeHeadersProvider.php
@@ -57,6 +57,6 @@ class CorsExposeHeadersProvider extends AbstractHeaderProvider implements Header
 
     public function canApply(): bool
     {
-        return $this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
+        return !$this->validator->isPreflightRequest() && $this->validator->originIsValid() && $this->getValue();
     }
 }


### PR DESCRIPTION
`Access-Control-Expose-Headers` should be only the full request, NOT the preflight:

> An HTTP response to a CORS request that is not a CORS-preflight request can also include the following header

https://fetch.spec.whatwg.org/#http-access-control-expose-headers

## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/graycoreio/magento2-cors/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

`Access-Control-Expose-Headers` is set on the preflight request and NOT on any other requests.


## What is the new behavior?
`Access-Control-Expose-Headers` is ONLY set on requests that are not preflight.

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information